### PR TITLE
Add single-use mental fuses with optional explosion effect

### DIFF
--- a/1.5/Source/AlteredCarbon/AlteredCarbon.csproj
+++ b/1.5/Source/AlteredCarbon/AlteredCarbon.csproj
@@ -65,6 +65,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="VAEInsanity">
       <HintPath>..\..\..\..\VanillaAnomalyExpanded-Insanity\1.5\Assemblies\VAEInsanity.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\workshop\content\294100\3342412435\1.5\Assemblies\VAEInsanity.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VAspirE">
@@ -73,6 +74,7 @@
     </Reference>
     <Reference Include="Vehicles">
       <HintPath>..\..\..\..\Vehicle-Framework\1.5\Assemblies\Vehicles.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\workshop\content\294100\3014915404\1.5\Assemblies\Vehicles.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VFEAncients">
@@ -81,10 +83,12 @@
     </Reference>
     <Reference Include="VFECore">
       <HintPath>..\..\..\..\VanillaExpandedFramework\1.5\Assemblies\VFECore.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\workshop\content\294100\2023507013\1.5\Assemblies\VFECore.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VREAndroids">
       <HintPath>..\..\..\..\VanillaRacesExpanded-Android\1.5\Assemblies\VREAndroids.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\workshop\content\294100\2975771801\1.5\Assemblies\VREAndroids.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VSE">

--- a/1.5/Source/AlteredCarbon/AlteredCarbonSettingsWorker_General.cs
+++ b/1.5/Source/AlteredCarbon/AlteredCarbonSettingsWorker_General.cs
@@ -13,11 +13,15 @@ namespace AlteredCarbon
     {
         public bool enableStackSpawning = true;
         public bool sleeveDeathDoesNotCauseGearTainting = true;
+        public bool singleUseMentalFuses = true;
+        public bool singleUseMentalFusePop = true;
 
         public override void ExposeData()
         {
             Scribe_Values.Look(ref enableStackSpawning, "enableStackSpawning", true);
             Scribe_Values.Look(ref sleeveDeathDoesNotCauseGearTainting, "sleeveDeathDoesNotCauseGearTainting", true);
+            Scribe_Values.Look(ref singleUseMentalFuses, "singleUseMentalFuses", true);
+            Scribe_Values.Look(ref singleUseMentalFusePop, "singleUseMentalFusePop", true);
         }
 
         public override void CopyFrom(PatchOperationWorker savedWorker)
@@ -25,18 +29,24 @@ namespace AlteredCarbon
             var copy = savedWorker as AlteredCarbonSettingsWorker_General;
             this.enableStackSpawning = copy.enableStackSpawning;
             this.sleeveDeathDoesNotCauseGearTainting = copy.sleeveDeathDoesNotCauseGearTainting;
+            this.singleUseMentalFuses = copy.singleUseMentalFuses;
+            this.singleUseMentalFusePop = copy.singleUseMentalFusePop;
         }
 
         public override void DoSettings(ModSettingsContainer container, Listing_Standard list)
         {
             DoCheckbox(list, "AC.EnableStackSpawning".Translate(), ref enableStackSpawning, "AC.EnableStackSpawningDesc".Translate());
             DoCheckbox(list, "AC.SleeveDeathDoesNotCauseGearTainting".Translate(), ref sleeveDeathDoesNotCauseGearTainting, null);
+            DoCheckbox(list, "AC.SingleUseMentalFuses".Translate(), ref singleUseMentalFuses, "AC.SingleUseMentalFusesDesc".Translate());
+            DoCheckbox(list, "AC.SingleUseMentalFusePop".Translate(), ref singleUseMentalFusePop, null);
         }
 
         public override void Reset()
         {
             enableStackSpawning = true;
             sleeveDeathDoesNotCauseGearTainting = true;
+            singleUseMentalFuses = true;
+            singleUseMentalFusePop = true;
         }
     }
 }

--- a/1.5/Source/AlteredCarbon/HarmonyPatches/MentalBreakWorker_TryStart_Patch.cs
+++ b/1.5/Source/AlteredCarbon/HarmonyPatches/MentalBreakWorker_TryStart_Patch.cs
@@ -15,7 +15,7 @@ public class MentalBreakWorker_TryStart_Patch
             return false;
         }
         
-        if (pawn.health.hediffSet.HasHediff(AC_DefOf.AC_MentalFuse))
+        if (pawn.health.hediffSet.TryGetHediff(AC_DefOf.AC_MentalFuse, out Hediff acMentalFuse))
         {
             //Send Letter
             var letter = LetterMaker.MakeLetter(
@@ -45,6 +45,24 @@ public class MentalBreakWorker_TryStart_Patch
                     "AC.MentalFuseTraumaLabel".Translate(),
                     "AC.MentalFuseTraumaText".Translate(pawn.Named("PAWN")).AdjustedFor(pawn),
                     LetterDefOf.NegativeEvent, pawn);
+            }
+
+            if (AC_Utils.generalSettings.singleUseMentalFuses)
+            {
+                pawn.health.RemoveHediff(acMentalFuse);
+                Messages.Message("AC.MentalFuseBlownText".Translate(pawn.Named("PAWN")), MessageTypeDefOf.NegativeHealthEvent);
+
+                if (AC_Utils.generalSettings.singleUseMentalFusePop)
+                {
+                    Effecter effecter = EffecterDefOf.ExtinguisherExplosion.Spawn();
+                    effecter.Trigger(new TargetInfo(pawn.Position, pawn.MapHeld),
+                        new TargetInfo(pawn.Position, pawn.MapHeld));
+                    effecter.Cleanup();
+                    GenExplosion.DoExplosion(pawn.Position, pawn.MapHeld, 2, DamageDefOf.Extinguish, null,
+                        explosionSound: SoundDefOf.Explosion_FirefoamPopper,
+                        postExplosionSpawnThingDef: ThingDefOf.Filth_FireFoam, postExplosionSpawnChance: 1f,
+                        applyDamageToExplosionCellsNeighbors: true);
+                }
             }
 
             return false;

--- a/Languages/English/Keyed/AlteredCarbon_Keys.xml
+++ b/Languages/English/Keyed/AlteredCarbon_Keys.xml
@@ -279,6 +279,9 @@ If you edit the content from a non-colonist stack from another faction, their en
 	<AC.EnableSoldNeuralStacksCreatingPawnDuplicatesDesc>text.todo</AC.EnableSoldNeuralStacksCreatingPawnDuplicatesDesc>
 	<AC.EnableNeuralStacksInAncientDangers>Enable neural stacks spawning in ancient dangers</AC.EnableNeuralStacksInAncientDangers>
 	<AC.EnableNeuralStacksInAncientDangersDesc>text.todo</AC.EnableNeuralStacksInAncientDangersDesc>
+	<AC.SingleUseMentalFuses>Enable single use mental fuses</AC.SingleUseMentalFuses>
+	<AC.SingleUseMentalFusesDesc>If enabled, mental fuses will "blow" when triggered, requiring a new one to be installed.</AC.SingleUseMentalFusesDesc>
+	<AC.SingleUseMentalFusePop>Enable "pop" when single use mental fuses blow.</AC.SingleUseMentalFusePop>
 	<!-- ================================ Warnings ====================== -->
 	<AC.CannotInstallStackOnAndroidWithoutNeuralModule>Cannot install stacks into androids without a neural module.</AC.CannotInstallStackOnAndroidWithoutNeuralModule>
 	<AC.CannotInstallEmptyStackInEmptySleeve>Cannot install an empty stack into an empty sleeve.</AC.CannotInstallEmptyStackInEmptySleeve>
@@ -295,6 +298,7 @@ If you edit the content from a non-colonist stack from another faction, their en
 	<AC.TriggeredMentalFuseText>{PAWN_nameDef}'s mental fuse has triggered, preventing a mental break.</AC.TriggeredMentalFuseText>
 	<AC.MentalFuseTraumaLabel>Mental fuse trauma</AC.MentalFuseTraumaLabel>
 	<AC.MentalFuseTraumaText>{PAWN_nameDef}'s mental fuse has caused permanent damage in {PAWN_objective} brain. This damage has caused {PAWN_objective} to develop strange savant-like abilities.</AC.MentalFuseTraumaText>
+	<AC.MentalFuseBlownText>{PAWN_nameDef}'s mental fuse has been destroyed, and will require replacement.</AC.MentalFuseBlownText>
 	<!-- ================================ Neural Connector ====================== -->
 	<AC.RequiresNeuralStackInstalled>Requires neural stack installed.</AC.RequiresNeuralStackInstalled>
 	<AC.CreateNeuralStack>Create neural stack</AC.CreateNeuralStack>


### PR DESCRIPTION
Adds settings to toggle mental fuses to be single use, and also to make them do a firefoam "pop" when they do blow. 